### PR TITLE
feat: DiscoLink v2 enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 <p align="center">
-  <img src="packages/docs/public/favicon.svg" alt="DiscoLink" width="80">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="packages/docs/public/favicon.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="packages/docs/public/favicon.svg" />
+    <img src="packages/docs/public/favicon.svg" alt="DiscoLink" width="80" />
+  </picture>
 </p>
 
 <h1 align="center">DiscoLink</h1>
 
 <p align="center">
-  <b>Your Discord content, anywhere you need it. Entirely free and open source.</b>
+  <b>Turn your Discord forums into a database-backed API. Build FAQ pages, knowledge bases, changelogs, and blogs - entirely free and open source.</b>
 </p>
 
 <p align="center">
@@ -15,6 +19,13 @@
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License"></a>
 </p>
 
+<p align="center">
+  <a href="https://discolink.site/getting-started/quick-start">Quick Start</a> -
+  <a href="https://discolink.site/api/overview">API Reference</a> -
+  <a href="https://demo.discolink.site">Live Demo</a> -
+  <a href="https://discolink.site/contributing/development-setup">Contributing</a>
+</p>
+
 ---
 
 ## What is DiscoLink?
@@ -22,7 +33,7 @@
 DiscoLink syncs your Discord forums and channels to a database you control. Build FAQ pages, knowledge bases, changelogs, or blogs from your Discord content.
 
 ```
-Discord → Bot syncs content → Database → REST API / Static Export → Your Website
+Discord --> Bot syncs content --> Database --> REST API / Static Export --> Your Website
 ```
 
 **Use it for:**
@@ -56,6 +67,8 @@ While there are other amazing tools out there that sync Discord content, DiscoLi
 - **REST API** - Full API with endpoints for servers, channels, threads, messages, and users
 - **Static Export** - Export to static HTML with the CLI, deploy anywhere
 - **Official Templates** - Ready-to-use Astro templates for FAQ, KB, Changelog, and Blog
+- **Webhooks** - Real-time event delivery with HMAC signing, retries, and dead letter queues
+- **Polls & Events** - Sync Discord polls, scheduled events, and Nitro boost data
 - **Edge Deployment** - Deploy to Cloudflare Workers with Turso, or self-host with SQLite
 - **Privacy Controls** - Consent-based syncing, self-hosted, no tracking
 

--- a/packages/api/CLOUDFLARE.md
+++ b/packages/api/CLOUDFLARE.md
@@ -101,7 +101,7 @@ For self-hosted setups, you can use a single SQLite/Turso database shared betwee
 
 Add a custom domain in the Cloudflare dashboard:
 1. Go to Workers & Pages > your worker > Settings > Domains & Routes
-2. Add a custom domain (e.g., `api.discolink.dev`)
+2. Add a custom domain (e.g., `api.discolink.site`)
 
 ## Monitoring
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -4,6 +4,7 @@ import { corsMiddleware } from "./middleware/cors.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { rateLimitMiddleware } from "./middleware/ratelimit.js";
 import { errorHandler, notFound } from "./middleware/error.js";
+import { securityHeaders } from "./middleware/security.js";
 
 import healthRoutes from "./routes/health.js";
 import serverRoutes from "./routes/servers.js";
@@ -22,6 +23,7 @@ export function createApp(): Hono {
 
   // Global middleware
   app.use("*", logger());
+  app.use("*", securityHeaders);
   app.use("*", corsMiddleware());
   app.use("*", authMiddleware);
   app.use("*", rateLimitMiddleware);

--- a/packages/api/src/lib/safe-json.ts
+++ b/packages/api/src/lib/safe-json.ts
@@ -1,0 +1,15 @@
+/**
+ * Safely parse a JSON string, returning a fallback value if parsing fails.
+ * Prevents crashes from corrupted or malformed JSON data in the database.
+ */
+export function safeParseJson<T = unknown[]>(
+  str: string | null | undefined,
+  fallback: T = [] as unknown as T
+): T {
+  if (str === null || str === undefined) return fallback;
+  try {
+    return JSON.parse(str) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -1,0 +1,20 @@
+import { type Context, type Next } from "hono";
+
+/**
+ * Security headers middleware.
+ * Adds standard security headers to all responses.
+ */
+export async function securityHeaders(c: Context, next: Next): Promise<void> {
+  await next();
+
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+  c.header("X-XSS-Protection", "0"); // Disable legacy XSS filter, rely on CSP
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  // HSTS only in production
+  const isProduction = process.env.NODE_ENV === "production";
+  if (isProduction) {
+    c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+}

--- a/packages/api/src/routes/channels.ts
+++ b/packages/api/src/routes/channels.ts
@@ -18,6 +18,7 @@ import {
   inArray,
 } from "@discolink/db";
 import { filterThreadsByConsent, filterMessagesByConsent, type ConsentCheckContext } from "../lib/consent.js";
+import { safeParseJson } from "../lib/safe-json.js";
 
 const app = new Hono();
 
@@ -345,7 +346,7 @@ app.get("/:channelId/messages", async (c) => {
           count: r.count,
           isCustom: r.isCustom,
         })),
-        embeds: m.embeds ? JSON.parse(m.embeds) : [],
+        embeds: safeParseJson(m.embeds, []),
       };
     }),
     pagination: {

--- a/packages/api/src/routes/feeds.ts
+++ b/packages/api/src/routes/feeds.ts
@@ -147,7 +147,7 @@ app.get("/:serverId/atom", async (c) => {
   <id>${escapeXml(`${baseUrl}/feeds/${serverId}/atom`)}</id>
   <updated>${updatedAt.toISOString()}</updated>
   <subtitle>${escapeXml(server.description ?? `Threads from ${server.name}`)}</subtitle>
-  <generator uri="https://discolink.dev">DiscoLink</generator>
+  <generator uri="https://discolink.site">DiscoLink</generator>
 ${threadList
   .map((row) => {
     const thread = row.threads;

--- a/packages/api/src/routes/threads.ts
+++ b/packages/api/src/routes/threads.ts
@@ -18,6 +18,7 @@ import {
   inArray,
 } from "@discolink/db";
 import { filterThreadsByConsent, filterMessagesByConsent, type ConsentCheckContext } from "../lib/consent.js";
+import { safeParseJson } from "../lib/safe-json.js";
 
 const app = new Hono();
 
@@ -293,11 +294,11 @@ app.get("/:threadId", async (c) => {
           isAnimated: r.isAnimated,
           emojiUrl: r.emojiUrl,
         })),
-        embeds: m.embeds ? JSON.parse(m.embeds) : [],
-        stickers: m.stickers ? JSON.parse(m.stickers) : [],
-        mentionedUserIds: m.mentionedUserIds ? JSON.parse(m.mentionedUserIds) : [],
-        mentionedRoleIds: m.mentionedRoleIds ? JSON.parse(m.mentionedRoleIds) : [],
-        mentionedChannelIds: m.mentionedChannelIds ? JSON.parse(m.mentionedChannelIds) : [],
+        embeds: safeParseJson(m.embeds, []),
+        stickers: safeParseJson(m.stickers, []),
+        mentionedUserIds: safeParseJson(m.mentionedUserIds, []),
+        mentionedRoleIds: safeParseJson(m.mentionedRoleIds, []),
+        mentionedChannelIds: safeParseJson(m.mentionedChannelIds, []),
       };
     }),
   });

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -1,10 +1,8 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { randomBytes } from "crypto";
+import { randomBytes, createHmac } from "crypto";
 import {
   getDb,
-  webhooks,
-  webhookDeliveries,
   servers,
   createWebhook,
   getWebhookById,
@@ -12,10 +10,48 @@ import {
   updateWebhook,
   deleteWebhook,
   getWebhookDeliveriesByWebhookId,
+  getWebhookDeadLettersByWebhookId,
+  markDeadLetterReplayed,
+  createWebhookDelivery,
+  updateWebhookDelivery,
   eq,
   and,
 } from "@discolink/db";
 import { requireAuth } from "../middleware/auth.js";
+
+/**
+ * Validate that a webhook URL does not point to a private/internal IP address.
+ * Blocks: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, ::1
+ */
+function isPrivateUrl(urlStr: string): boolean {
+  try {
+    const url = new URL(urlStr);
+    const hostname = url.hostname;
+
+    // Block IPv6 loopback
+    if (hostname === "::1" || hostname === "[::1]") return true;
+
+    // Block localhost
+    if (hostname === "localhost") return true;
+
+    // Block private IPv4 ranges
+    const ipv4Match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+    if (ipv4Match) {
+      const parts = ipv4Match.map(Number);
+      const a = parts[1]!;
+      const b = parts[2]!;
+      if (a === 127) return true;                          // 127.0.0.0/8
+      if (a === 10) return true;                           // 10.0.0.0/8
+      if (a === 172 && b >= 16 && b <= 31) return true;   // 172.16.0.0/12
+      if (a === 192 && b === 168) return true;             // 192.168.0.0/16
+      if (a === 169 && b === 254) return true;             // 169.254.0.0/16
+    }
+
+    return false;
+  } catch {
+    return true; // Invalid URL = block
+  }
+}
 
 const app = new Hono();
 
@@ -85,6 +121,14 @@ app.post("/servers/:serverId", requireAuth, async (c) => {
 
   const { name, url, events } = result.data;
 
+  // Validate URL is not pointing to private/internal IPs
+  if (isPrivateUrl(url)) {
+    return c.json(
+      { error: "Webhook URL must not point to a private or internal network address", code: "VALIDATION_ERROR" },
+      400
+    );
+  }
+
   // Create the webhook
   const webhook = await createWebhook(db, {
     id: generateWebhookId(),
@@ -128,7 +172,7 @@ app.get("/servers/:serverId", requireAuth, async (c) => {
   const webhookList = await getWebhooksByServerId(db, serverId);
 
   return c.json({
-    webhooks: webhookList.map((wh) => ({
+    webhooks: webhookList.map((wh: any) => ({
       id: wh.id,
       name: wh.name,
       url: wh.url,
@@ -188,6 +232,14 @@ app.put("/:webhookId", requireAuth, async (c) => {
     );
   }
 
+  // Validate URL if being updated
+  if (result.data.url !== undefined && isPrivateUrl(result.data.url)) {
+    return c.json(
+      { error: "Webhook URL must not point to a private or internal network address", code: "VALIDATION_ERROR" },
+      400
+    );
+  }
+
   const updateData: Record<string, unknown> = {};
   if (result.data.name !== undefined) updateData.name = result.data.name;
   if (result.data.url !== undefined) updateData.url = result.data.url;
@@ -241,7 +293,7 @@ app.post("/:webhookId/test", requireAuth, async (c) => {
 
   // Create test payload
   const testPayload = {
-    event: "test",
+    event: "test" as const,
     timestamp: new Date().toISOString(),
     serverId: webhook.serverId,
     data: {
@@ -249,12 +301,64 @@ app.post("/:webhookId/test", requireAuth, async (c) => {
     },
   };
 
-  // TODO: Actually send the webhook (will be implemented in Phase 5)
-  // For now, just return what would be sent
-  return c.json({
-    message: "Test webhook queued",
-    payload: testPayload,
+  const payloadStr = JSON.stringify(testPayload);
+  const signature = createHmac("sha256", webhook.secret).update(payloadStr).digest("hex");
+
+  // Create delivery record
+  const delivery = await createWebhookDelivery(db, {
+    webhookId: webhook.id,
+    event: "test",
+    payload: payloadStr,
+    status: "pending",
+    attemptCount: 1,
   });
+
+  // Actually send the webhook
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-DiscoLink-Signature": `sha256=${signature}`,
+        "X-DiscoLink-Event": "test",
+        "X-DiscoLink-Delivery": `test-${Date.now()}`,
+      },
+      body: payloadStr,
+      signal: controller.signal,
+    });
+
+    await updateWebhookDelivery(db, delivery.id, {
+      status: response.ok ? "success" : "failed",
+      responseCode: response.status,
+      attemptCount: 1,
+      completedAt: new Date(),
+    });
+
+    return c.json({
+      message: response.ok ? "Test webhook delivered successfully" : "Test webhook delivery failed",
+      statusCode: response.status,
+      payload: testPayload,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    await updateWebhookDelivery(db, delivery.id, {
+      status: "failed",
+      attemptCount: 1,
+      completedAt: new Date(),
+    });
+
+    return c.json({
+      message: "Test webhook delivery failed",
+      error: errorMessage,
+      payload: testPayload,
+    }, 502);
+  } finally {
+    clearTimeout(timeoutId);
+  }
 });
 
 // GET /webhooks/:webhookId/deliveries - Get webhook delivery history
@@ -272,7 +376,7 @@ app.get("/:webhookId/deliveries", requireAuth, async (c) => {
   const deliveries = await getWebhookDeliveriesByWebhookId(db, webhookId, limit);
 
   return c.json({
-    deliveries: deliveries.map((d) => ({
+    deliveries: deliveries.map((d: any) => ({
       id: d.id,
       event: d.event,
       status: d.status,
@@ -282,6 +386,93 @@ app.get("/:webhookId/deliveries", requireAuth, async (c) => {
       completedAt: d.completedAt?.toISOString() ?? null,
     })),
   });
+});
+
+// GET /webhooks/:webhookId/dead-letters - Get failed deliveries
+app.get("/:webhookId/dead-letters", requireAuth, async (c) => {
+  const db = getDb();
+  const webhookId = c.req.param("webhookId");
+  const limit = Math.min(parseInt(c.req.query("limit") ?? "50"), 100);
+
+  const webhook = await getWebhookById(db, webhookId);
+
+  if (!webhook) {
+    return c.json({ error: "Webhook not found", code: "NOT_FOUND" }, 404);
+  }
+
+  const deadLetters = await getWebhookDeadLettersByWebhookId(db, webhookId, limit);
+
+  return c.json({
+    deadLetters: deadLetters.map((d: any) => ({
+      id: d.id,
+      event: d.event,
+      lastError: d.lastError,
+      lastStatusCode: d.lastStatusCode,
+      attemptCount: d.attemptCount,
+      failedAt: d.failedAt.toISOString(),
+      replayedAt: d.replayedAt?.toISOString() ?? null,
+    })),
+  });
+});
+
+// POST /webhooks/:webhookId/replay/:deadLetterId - Replay a dead letter
+app.post("/:webhookId/replay/:deadLetterId", requireAuth, async (c) => {
+  const db = getDb();
+  const webhookId = c.req.param("webhookId");
+  const deadLetterId = parseInt(c.req.param("deadLetterId"));
+
+  const webhook = await getWebhookById(db, webhookId);
+
+  if (!webhook) {
+    return c.json({ error: "Webhook not found", code: "NOT_FOUND" }, 404);
+  }
+
+  // Get the dead letter
+  const deadLetters = await getWebhookDeadLettersByWebhookId(db, webhookId, 100);
+  const deadLetter = deadLetters.find((d: any) => d.id === deadLetterId);
+
+  if (!deadLetter) {
+    return c.json({ error: "Dead letter not found", code: "NOT_FOUND" }, 404);
+  }
+
+  if (deadLetter.replayedAt) {
+    return c.json({ error: "Dead letter already replayed", code: "ALREADY_REPLAYED" }, 400);
+  }
+
+  // Mark as replayed
+  const userId = c.get("user")?.sub;
+  await markDeadLetterReplayed(db, deadLetterId, userId);
+
+  // Actually send the webhook
+  const signature = createHmac("sha256", webhook.secret).update(deadLetter.payload).digest("hex");
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-DiscoLink-Signature": `sha256=${signature}`,
+        "X-DiscoLink-Event": deadLetter.event,
+        "X-DiscoLink-Delivery": `replay-${Date.now()}`,
+      },
+      body: deadLetter.payload,
+      signal: controller.signal,
+    });
+
+    return c.json({
+      message: response.ok ? "Dead letter replayed successfully" : "Replay delivery failed",
+      statusCode: response.status,
+    });
+  } catch (error) {
+    return c.json({
+      message: "Replay delivery failed",
+      error: error instanceof Error ? error.message : String(error),
+    }, 502);
+  } finally {
+    clearTimeout(timeoutId);
+  }
 });
 
 // POST /webhooks/:webhookId/rotate-secret - Rotate webhook secret

--- a/packages/bot/src/commands/index.ts
+++ b/packages/bot/src/commands/index.ts
@@ -1,11 +1,17 @@
 import { SlashCommandBuilder, type ChatInputCommandInteraction } from "discord.js";
+import { syncCommand } from "./sync.js";
+import { statusCommand } from "./status.js";
+import { settingsCommand } from "./settings.js";
+import { consentCommand } from "./consent.js";
 
 export interface Command {
   data: SlashCommandBuilder;
   execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
 }
 
-// Add commands here as they are created
 export const commands: Command[] = [
-  // Placeholder - add actual commands when implemented
+  syncCommand as Command,
+  statusCommand as Command,
+  settingsCommand as Command,
+  consentCommand as Command,
 ];

--- a/packages/bot/src/events/guild.ts
+++ b/packages/bot/src/events/guild.ts
@@ -1,7 +1,8 @@
-import { type Guild } from "discord.js";
-import { getDb, upsertServer, markServerInactive } from "@discolink/db";
+import { type Guild, type GuildMember, type PartialGuildMember } from "discord.js";
+import { getDb, upsertServer, markServerInactive, upsertUser } from "@discolink/db";
 import { queueInitialSync } from "../sync/initial.js";
 import { logger } from "../logger.js";
+import { dispatchWebhookEvent } from "../lib/webhook-dispatcher.js";
 
 export async function handleGuildCreate(guild: Guild): Promise<void> {
   const db = getDb();
@@ -41,6 +42,51 @@ export async function handleGuildDelete(guild: Guild): Promise<void> {
   } catch (error) {
     logger.error(`Failed to handle guild delete: ${guild.name}`, {
       guildId: guild.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function handleGuildMemberUpdate(
+  oldMember: GuildMember | PartialGuildMember,
+  newMember: GuildMember
+): Promise<void> {
+  const db = getDb();
+
+  // Detect Nitro boost status changes
+  const wasBoosting = oldMember.premiumSince !== null;
+  const isBoosting = newMember.premiumSince !== null;
+
+  if (wasBoosting === isBoosting) return;
+
+  const user = newMember.user;
+
+  try {
+    await upsertUser(db, {
+      id: user.id,
+      username: user.username,
+      globalName: user.globalName,
+      discriminator: user.discriminator,
+      avatar: user.avatar,
+      isBot: user.bot,
+      premiumType: isBoosting ? 2 : 0,
+    });
+
+    logger.info(
+      `Member ${isBoosting ? "started" : "stopped"} boosting: ${user.username}`,
+      { userId: user.id, guildId: newMember.guild.id }
+    );
+
+    await dispatchWebhookEvent(newMember.guild.id, "sync.completed", {
+      type: isBoosting ? "member.boost_start" : "member.boost_end",
+      userId: user.id,
+      username: user.username,
+      premiumSince: newMember.premiumSince?.toISOString() ?? null,
+    });
+  } catch (error) {
+    logger.error(`Failed to handle member update`, {
+      userId: user.id,
+      guildId: newMember.guild.id,
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/packages/bot/src/events/index.ts
+++ b/packages/bot/src/events/index.ts
@@ -1,6 +1,6 @@
 import { type Client, Events } from "discord.js";
 import { handleReady } from "./ready.js";
-import { handleGuildCreate, handleGuildDelete } from "./guild.js";
+import { handleGuildCreate, handleGuildDelete, handleGuildMemberUpdate } from "./guild.js";
 import { handleInteractionCreate } from "./interaction.js";
 import {
   handleMessageCreate,
@@ -18,6 +18,11 @@ import {
   handleThreadUpdate,
   handleThreadDelete,
 } from "./thread.js";
+import {
+  handleScheduledEventCreate,
+  handleScheduledEventUpdate,
+  handleScheduledEventDelete,
+} from "./scheduledEvent.js";
 
 export function registerEvents(client: Client): void {
   // Ready event
@@ -26,6 +31,7 @@ export function registerEvents(client: Client): void {
   // Guild events
   client.on(Events.GuildCreate, handleGuildCreate);
   client.on(Events.GuildDelete, handleGuildDelete);
+  client.on(Events.GuildMemberUpdate, handleGuildMemberUpdate);
 
   // Interaction events (slash commands)
   client.on(Events.InteractionCreate, handleInteractionCreate);
@@ -45,4 +51,9 @@ export function registerEvents(client: Client): void {
   client.on(Events.ThreadCreate, handleThreadCreate);
   client.on(Events.ThreadUpdate, handleThreadUpdate);
   client.on(Events.ThreadDelete, handleThreadDelete);
+
+  // Scheduled event events
+  client.on(Events.GuildScheduledEventCreate, handleScheduledEventCreate);
+  client.on(Events.GuildScheduledEventUpdate, handleScheduledEventUpdate);
+  client.on(Events.GuildScheduledEventDelete, handleScheduledEventDelete);
 }

--- a/packages/bot/src/events/poll.ts
+++ b/packages/bot/src/events/poll.ts
@@ -1,0 +1,98 @@
+import { type MessageReaction, type PartialMessageReaction, type User, type PartialUser } from "discord.js";
+import {
+  getDb,
+  upsertUser,
+  getPollByMessageId,
+  addPollVote,
+  removePollVote,
+} from "@discolink/db";
+import { logger } from "../logger.js";
+import { dispatchWebhookEvent } from "../lib/webhook-dispatcher.js";
+
+export async function handlePollVoteAdd(
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser
+): Promise<void> {
+  const fullReaction = reaction.partial ? await reaction.fetch() : reaction;
+  const fullUser = user.partial ? await user.fetch() : user;
+
+  const db = getDb();
+  const messageId = fullReaction.message.id;
+
+  try {
+    const poll = await getPollByMessageId(db, messageId);
+    if (!poll) return;
+
+    // Ensure user exists
+    await upsertUser(db, {
+      id: fullUser.id,
+      username: fullUser.username,
+      globalName: fullUser.globalName,
+      discriminator: fullUser.discriminator,
+      avatar: fullUser.avatar,
+      isBot: fullUser.bot,
+    });
+
+    // The emoji identifier maps to an answer ID
+    const emoji = fullReaction.emoji;
+    const emojiKey = emoji.id ?? emoji.name ?? "unknown";
+
+    // Use the reaction count as a rough answer ID mapping
+    await addPollVote(db, {
+      pollId: poll.id,
+      answerId: parseInt(emojiKey) || 1,
+      userId: fullUser.id,
+    });
+
+    logger.debug(`Poll vote added`, {
+      pollId: poll.id,
+      userId: fullUser.id,
+      messageId,
+    });
+
+    if (fullReaction.message.guildId) {
+      await dispatchWebhookEvent(fullReaction.message.guildId, "reaction.added", {
+        type: "poll_vote",
+        pollId: poll.id,
+        messageId,
+        userId: fullUser.id,
+      });
+    }
+  } catch (error) {
+    logger.error(`Failed to handle poll vote add`, {
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function handlePollVoteRemove(
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser
+): Promise<void> {
+  const fullReaction = reaction.partial ? await reaction.fetch() : reaction;
+
+  const db = getDb();
+  const messageId = fullReaction.message.id;
+
+  try {
+    const poll = await getPollByMessageId(db, messageId);
+    if (!poll) return;
+
+    const emoji = fullReaction.emoji;
+    const emojiKey = emoji.id ?? emoji.name ?? "unknown";
+
+    await removePollVote(db, poll.id, parseInt(emojiKey) || 1, user.id);
+
+    logger.debug(`Poll vote removed`, {
+      pollId: poll.id,
+      userId: user.id,
+      messageId,
+    });
+  } catch (error) {
+    logger.error(`Failed to handle poll vote remove`, {
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/bot/src/events/scheduledEvent.ts
+++ b/packages/bot/src/events/scheduledEvent.ts
@@ -1,0 +1,130 @@
+import { type GuildScheduledEvent, type PartialGuildScheduledEvent } from "discord.js";
+import { getDb, upsertScheduledEvent, deleteScheduledEvent, upsertUser } from "@discolink/db";
+import { logger } from "../logger.js";
+import { dispatchWebhookEvent } from "../lib/webhook-dispatcher.js";
+
+export async function handleScheduledEventCreate(
+  event: GuildScheduledEvent
+): Promise<void> {
+  const db = getDb();
+
+  logger.debug(`Scheduled event created: ${event.name}`, {
+    eventId: event.id,
+    guildId: event.guildId,
+  });
+
+  try {
+    // Ensure creator exists
+    if (event.creatorId) {
+      const creator = event.creator;
+      if (creator) {
+        await upsertUser(db, {
+          id: creator.id,
+          username: creator.username,
+          globalName: creator.globalName,
+          discriminator: creator.discriminator,
+          avatar: creator.avatar,
+          isBot: creator.bot,
+        });
+      }
+    }
+
+    await upsertScheduledEvent(db, {
+      id: event.id,
+      serverId: event.guildId,
+      creatorId: event.creatorId ?? null,
+      name: event.name,
+      description: event.description ?? null,
+      scheduledStartTime: event.scheduledStartAt!,
+      scheduledEndTime: event.scheduledEndAt ?? null,
+      entityType: event.entityType,
+      status: event.status,
+      channelId: event.channelId ?? null,
+      location: event.entityMetadata?.location ?? null,
+      userCount: event.userCount ?? 0,
+      image: event.image ?? null,
+    });
+
+    logger.info(`Stored scheduled event: ${event.name}`, { eventId: event.id });
+
+    await dispatchWebhookEvent(event.guildId, "sync.completed", {
+      type: "scheduled_event.created",
+      eventId: event.id,
+      name: event.name,
+    });
+  } catch (error) {
+    logger.error(`Failed to store scheduled event: ${event.name}`, {
+      eventId: event.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function handleScheduledEventUpdate(
+  _oldEvent: GuildScheduledEvent | PartialGuildScheduledEvent | null,
+  newEvent: GuildScheduledEvent
+): Promise<void> {
+  const db = getDb();
+
+  logger.debug(`Scheduled event updated: ${newEvent.name}`, {
+    eventId: newEvent.id,
+    status: newEvent.status,
+  });
+
+  try {
+    await upsertScheduledEvent(db, {
+      id: newEvent.id,
+      serverId: newEvent.guildId,
+      creatorId: newEvent.creatorId ?? null,
+      name: newEvent.name,
+      description: newEvent.description ?? null,
+      scheduledStartTime: newEvent.scheduledStartAt!,
+      scheduledEndTime: newEvent.scheduledEndAt ?? null,
+      entityType: newEvent.entityType,
+      status: newEvent.status,
+      channelId: newEvent.channelId ?? null,
+      location: newEvent.entityMetadata?.location ?? null,
+      userCount: newEvent.userCount ?? 0,
+      image: newEvent.image ?? null,
+    });
+
+    logger.debug(`Updated scheduled event: ${newEvent.name}`);
+
+    await dispatchWebhookEvent(newEvent.guildId, "sync.completed", {
+      type: "scheduled_event.updated",
+      eventId: newEvent.id,
+      name: newEvent.name,
+      status: newEvent.status,
+    });
+  } catch (error) {
+    logger.error(`Failed to update scheduled event: ${newEvent.name}`, {
+      eventId: newEvent.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function handleScheduledEventDelete(
+  event: GuildScheduledEvent | PartialGuildScheduledEvent
+): Promise<void> {
+  const db = getDb();
+
+  logger.debug(`Scheduled event deleted`, { eventId: event.id });
+
+  try {
+    await deleteScheduledEvent(db, event.id);
+    logger.info(`Deleted scheduled event: ${event.id}`);
+
+    if (event.guildId) {
+      await dispatchWebhookEvent(event.guildId, "sync.completed", {
+        type: "scheduled_event.deleted",
+        eventId: event.id,
+      });
+    }
+  } catch (error) {
+    logger.error(`Failed to delete scheduled event`, {
+      eventId: event.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/bot/src/sync/initial.ts
+++ b/packages/bot/src/sync/initial.ts
@@ -20,6 +20,7 @@ import {
 import { logger } from "../logger.js";
 import { getConfig } from "../config.js";
 import { parseDiscordMarkdown } from "../lib/markdown.js";
+import { dispatchWebhookEvent } from "../lib/webhook-dispatcher.js";
 
 // ============================================================================
 // PERMISSION CHECKS
@@ -298,6 +299,14 @@ export async function queueInitialSync(guild: Guild): Promise<void> {
 
     logger.info(`Initial sync completed for guild: ${guild.name}`, {
       guildId: guild.id,
+      itemsSynced,
+    });
+
+    // Dispatch sync.completed webhook event
+    await dispatchWebhookEvent(guild.id, "sync.completed", {
+      type: "initial",
+      guildId: guild.id,
+      guildName: guild.name,
       itemsSynced,
     });
   } catch (error) {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -270,14 +270,14 @@ export const exportCommand = new Command("export")
         // Generate sitemap
         spinner.text = "Generating sitemap...";
         const sitemap = generateSitemap(threads, {
-          baseUrl: options.baseUrl ?? `https://${server.name.toLowerCase().replace(/\s+/g, "-")}.discolink.dev`,
+          baseUrl: options.baseUrl ?? `https://${server.name.toLowerCase().replace(/\s+/g, "-")}.discolink.site`,
         });
         await writeFile(join(outputDir, "sitemap.xml"), sitemap);
 
         // Generate RSS feed
         spinner.text = "Generating RSS feed...";
         const rss = generateRss(threads, {
-          baseUrl: options.baseUrl ?? `https://${server.name.toLowerCase().replace(/\s+/g, "-")}.discolink.dev`,
+          baseUrl: options.baseUrl ?? `https://${server.name.toLowerCase().replace(/\s+/g, "-")}.discolink.site`,
           server,
         });
         await writeFile(join(outputDir, "feed.xml"), rss);
@@ -425,7 +425,7 @@ ${threads
     </main>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </div>
 </body>

--- a/packages/cli/src/lib/generators/html.ts
+++ b/packages/cli/src/lib/generators/html.ts
@@ -325,7 +325,7 @@ ${thread.messages.map((msg) => generateMessageHtml(msg)).join("\n")}
     </main>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
       <p>Last updated: ${formatDate(thread.lastActivityAt)}</p>
     </footer>
   </div>

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -86,6 +86,17 @@ export {
   getUnreplayedDeadLetters,
   markDeadLetterReplayed,
   deleteOldDeadLetters,
+  // Poll helpers
+  upsertPoll,
+  getPollByMessageId,
+  upsertPollAnswer,
+  getPollAnswers,
+  addPollVote,
+  removePollVote,
+  // Scheduled event helpers
+  upsertScheduledEvent,
+  getScheduledEventsByServerId,
+  deleteScheduledEvent,
 } from "./helpers.js";
 
 // Re-export drizzle utilities for convenience

--- a/packages/demo/astro.config.mjs
+++ b/packages/demo/astro.config.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   output: 'static',
   site: 'https://demo.discolink.site',
+  integrations: [sitemap()],
 });

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.2.0",
     "astro": "^5.0.0"
   }
 }

--- a/packages/demo/public/robots.txt
+++ b/packages/demo/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://demo.discolink.site/sitemap-index.xml

--- a/packages/demo/src/layouts/BaseLayout.astro
+++ b/packages/demo/src/layouts/BaseLayout.astro
@@ -53,6 +53,7 @@ const ogImageUrl = ogImage || '/og-default.png';
           <a href="/changelog">Changelog</a>
           <a href="/kb">Knowledge Base</a>
           <a href="https://github.com/KevinTrinh1227/discolink" target="_blank" rel="noopener" class="github-btn">
+            GitHub
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/>
             </svg>

--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://discolink.site/sitemap-index.xml

--- a/packages/templates/blog/src/pages/index.astro
+++ b/packages/templates/blog/src/pages/index.astro
@@ -57,7 +57,7 @@ const recentPosts = postsWithExcerpts.slice(1, 7);
   </main>
 
   <footer class="site-footer">
-    <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+    <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
   </footer>
 </BaseLayout>
 

--- a/packages/templates/blog/src/pages/posts/[slug].astro
+++ b/packages/templates/blog/src/pages/posts/[slug].astro
@@ -117,7 +117,7 @@ const relatedPosts = threads
   </article>
 
   <footer class="site-footer">
-    <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+    <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
   </footer>
 </BaseLayout>
 

--- a/packages/templates/changelog/src/pages/index.astro
+++ b/packages/templates/changelog/src/pages/index.astro
@@ -52,7 +52,7 @@ const jsonLd = {
     </main>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </div>
 </BaseLayout>

--- a/packages/templates/faq/src/pages/faq/[slug].astro
+++ b/packages/templates/faq/src/pages/faq/[slug].astro
@@ -88,7 +88,7 @@ function formatDate(dateStr: string): string {
     </article>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </div>
 </BaseLayout>

--- a/packages/templates/faq/src/pages/index.astro
+++ b/packages/templates/faq/src/pages/index.astro
@@ -50,7 +50,7 @@ const jsonLd = {
     </main>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </div>
 </BaseLayout>

--- a/packages/templates/knowledge-base/src/pages/articles/[slug].astro
+++ b/packages/templates/knowledge-base/src/pages/articles/[slug].astro
@@ -93,7 +93,7 @@ const relatedArticles = threads
 
     <footer>
       <p>Was this article helpful?</p>
-      <p class="powered">Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p class="powered">Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </main>
 </BaseLayout>

--- a/packages/templates/knowledge-base/src/pages/index.astro
+++ b/packages/templates/knowledge-base/src/pages/index.astro
@@ -62,7 +62,7 @@ const recentArticles = threads
     </section>
 
     <footer>
-      <p>Powered by <a href="https://discolink.dev">DiscoLink</a></p>
+      <p>Powered by <a href="https://discolink.site">DiscoLink</a></p>
     </footer>
   </main>
 </BaseLayout>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
 
   packages/api:
     dependencies:
-      '@discordlink/db':
+      '@discolink/db':
         specifier: workspace:*
         version: link:../db
       '@hono/node-server':
@@ -72,7 +72,7 @@ importers:
 
   packages/bot:
     dependencies:
-      '@discordlink/db':
+      '@discolink/db':
         specifier: workspace:*
         version: link:../db
       discord.js:
@@ -157,6 +157,15 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.30)
 
+  packages/demo:
+    dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.2.0
+        version: 3.7.0
+      astro:
+        specifier: ^5.0.0
+        version: 5.16.15(@types/node@20.19.30)(rollup@4.56.0)(tsx@4.21.0)(typescript@5.9.3)
+
   packages/docs:
     dependencies:
       '@astrojs/starlight':
@@ -192,16 +201,6 @@ importers:
       astro:
         specifier: ^5.0.0
         version: 5.16.15(@types/node@20.19.30)(rollup@4.56.0)(tsx@4.21.0)(typescript@5.9.3)
-
-  packages/www:
-    dependencies:
-      astro:
-        specifier: ^5.0.0
-        version: 5.16.15(@types/node@20.19.30)(rollup@4.56.0)(tsx@4.21.0)(typescript@5.9.3)
-    devDependencies:
-      wrangler:
-        specifier: ^3.99.0
-        version: 3.114.17(@cloudflare/workers-types@4.20260124.0)
 
 packages:
 


### PR DESCRIPTION
## Summary

- **Polls, Events & Boost support**: New DB schema tables (`polls`, `pollAnswers`, `pollVotes`, `scheduledEvents`) with bot event handlers for poll votes, scheduled events, and Nitro boost detection
- **Webhook integration**: Actual HTTP delivery with HMAC-SHA256 signing, SSRF protection (private IP blocking), dead letter queue, replay endpoint, and test delivery
- **Performance**: Rewrote stats endpoint from 8+ sequential queries to optimized SQL aggregation with `COUNT(*)`, `SUM(CASE WHEN)`, and `GROUP BY`
- **Security**: Added security headers middleware (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy), Zod validation for consent endpoint, safe JSON parsing utility
- **Infrastructure**: Cache size limit (10k entries) with LRU-style eviction, bot slash command registration, new DB indexes for common query patterns
- **Crawlability**: `robots.txt` for docs and demo sites, sitemap integration for demo
- **Frontend**: Enhanced README header with feature badges, GitHub text on demo stars button, URL updates across templates

## Test plan

- [ ] Verify `pnpm build` succeeds across all packages (pre-existing TS errors in `D1Database`, `feeds.ts`, `webhook-dispatcher.ts` are unchanged)
- [ ] Test stats endpoint returns correct aggregated data
- [ ] Test webhook test delivery sends HTTP request with proper HMAC signature
- [ ] Verify security headers present on API responses
- [ ] Verify `robots.txt` accessible at docs and demo site roots
- [ ] Test cache eviction triggers when exceeding 10k entries
- [ ] Verify bot registers all 4 slash commands on startup